### PR TITLE
Update note in README about using generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Our app will have two pages:
 
 1. Create the sessions controller.
 
-   **Note:** If you use the generators to generate your controllers be sure to pass these
-   flags to avoid generating unneeded files: `rails generate controller Sessions new --no-helper --no-assets --no-controller-specs`.
+   **Note:** If you use the generators to generate your controllers, be sure to pass these
+   flags to avoid generating unneeded files and routes: `rails generate controller Sessions new --no-helper --no-assets --no-test-framework --skip-routes --skip`. (For those who are curious, the `--skip` tag prevents the generator from conflicting with existing files.)
 
 2. Write the `new`, `create`, and `destroy` methods.
 


### PR DESCRIPTION
I updated the README because when I followed its instructions about using generators,
I ran into a conflict with existing files, and I still got a few unnecessary files and routes.

Another note: I replaced the --no-controller-specs tag with --no-test-framework in order to prevent controller specs AND view specs from being generated.